### PR TITLE
[FIX/REFACTOR] - Fixed issues in contextMenu and refactor

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -1,49 +1,44 @@
 /* Copyright 2017 Abner Soares Alves Junior
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
+distributed under the License is distributed on an 'AS IS' BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
-function lookup(selection) {
-    var selectionText = encodeURI(selection.selectionText);
-    chrome.tabs.create({
-        "url": "http://www.urbandictionary.com/define.php?term=" + selectionText
-    });
-    return true;
-}
 
-function lookupInjected() {
+const newChromeTab = (...conf) => chrome.tabs.create.apply(this, conf)
+
+const lookup = (selectionText) => 
+  newChromeTab({
+    'url': 'http://www.urbandictionary.com/define.php?term=' + encodeURI(selectionText)
+  })
+
+const lookupInjected = ()  => {
     chrome.tabs.executeScript(null, {
-        code: 'var text = ""; if (window.getSelection) { text = window.getSelection().toString(); } else if (document.selection && document.selection.type != "Control") { text = document.selection.createRange().text; } { selectionText: text }'
-    }, function(results) {
-        lookup({ selectionText: results })
-    })
+        code: `const text = getSelection ? getSelection().toString() 
+                              : (selection && selection.type !== 'Control') ? selection.createRange().text : ''`
+    }, lookup)
 }
 
-chrome.commands.onCommand.addListener(function(command){
-    if(command === "urban-lookup") {
-        lookupInjected()
-    }
-});
+chrome.commands.onCommand.addListener(command => command === 'urban-lookup'? lookupInjected(): false )
 
 chrome.contextMenus.onClicked.addListener(lookup);
 chrome.browserAction.onClicked.addListener(lookupInjected);
 
 chrome.runtime.onInstalled.addListener(function () {
     chrome.contextMenus.create({
-        "id": "urbanDictionaryContext",
-        "title": "Lookup the selected text on Urban Directory",
-        "contexts": ["selection"]
+        'id': 'urbanDictionaryContext',
+        'title': 'Lookup the selected text on Urban Directory',
+        'contexts': ['selection']
     }, function () {
         if (chrome.extension.lastError) {
-            console.error("Got expected error: " + chrome.extension.lastError.message);
+            console.error('Got expected error: ' + chrome.extension.lastError.message);
         }
     });
 });

--- a/contentscript.js
+++ b/contentscript.js
@@ -25,10 +25,10 @@ const lookupInjected = ()  => {
     }, lookup)
 }
 
-chrome.commands.onCommand.addListener(command => command === 'urban-lookup'? lookupInjected(): false )
+chrome.commands.onCommand.addListener(command => command === 'urban-lookup' && lookupInjected() )
 
-chrome.contextMenus.onClicked.addListener(lookup);
-chrome.browserAction.onClicked.addListener(lookupInjected);
+chrome.contextMenus.onClicked.addListener(lookupInjected)
+chrome.browserAction.onClicked.addListener(lookupInjected)
 
 chrome.runtime.onInstalled.addListener(function () {
     chrome.contextMenus.create({

--- a/contentscript.js
+++ b/contentscript.js
@@ -21,8 +21,7 @@ const lookup = (selectionText) =>
 
 const lookupInjected = ()  => {
     chrome.tabs.executeScript(null, {
-        code: `const text = getSelection ? getSelection().toString() 
-                              : (selection && selection.type !== 'Control') ? selection.createRange().text : ''`
+        code: `let text = ''; text = window.getSelection().toString() || document.selection.createRange().text || ''`
     }, lookup)
 }
 

--- a/contentscript.js
+++ b/contentscript.js
@@ -21,7 +21,7 @@ const lookup = (selectionText) =>
 
 const lookupInjected = ()  => {
     chrome.tabs.executeScript(null, {
-        code: `let text = ''; text = window.getSelection().toString() || document.selection.createRange().text || ''`
+        code: `let text = ''; text = window.getSelection().toString() || selection.createRange().text`
     }, lookup)
 }
 

--- a/contentscript.js
+++ b/contentscript.js
@@ -12,32 +12,42 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+
+const newContextMenu = ({ id = '', title = '', contexts = [] }) => {
+    chrome.contextMenus.create({
+        id,
+        title,
+        contexts
+    }, () => {
+        if (chrome.extension.lastError) {
+            throw new Error('Got expected error: ' + chrome.extension.lastError.message);
+        }
+    })
+}
+
 const newChromeTab = (...conf) => chrome.tabs.create.apply(this, conf)
 
-const lookup = (selectionText) => 
-  newChromeTab({
-    'url': 'http://www.urbandictionary.com/define.php?term=' + encodeURI(selectionText)
-  })
+const lookup = (selectionText) =>
+    newChromeTab({
+        'url': 'http://www.urbandictionary.com/define.php?term=' + encodeURI(selectionText)
+    })
 
-const lookupInjected = ()  => {
+const lookupInjected = () => {
     chrome.tabs.executeScript(null, {
         code: `let text = ''; text = window.getSelection().toString() || selection.createRange().text`
     }, lookup)
 }
 
-chrome.commands.onCommand.addListener(command => command === 'urban-lookup' && lookupInjected() )
+chrome.commands.onCommand.addListener(command => command === 'urban-lookup' && lookupInjected())
 
 chrome.contextMenus.onClicked.addListener(lookupInjected)
 chrome.browserAction.onClicked.addListener(lookupInjected)
 
 chrome.runtime.onInstalled.addListener(function () {
-    chrome.contextMenus.create({
-        'id': 'urbanDictionaryContext',
-        'title': 'Lookup the selected text on Urban Directory',
-        'contexts': ['selection']
-    }, function () {
-        if (chrome.extension.lastError) {
-            console.error('Got expected error: ' + chrome.extension.lastError.message);
-        }
-    });
-});
+    const contextMenuConfig = {
+        id: 'urbanDictionaryContext',
+        title: 'Lookup the selected text on Urban Directory',
+        contexts: ['selection']
+    }
+    newContextMenu(contextMenuConfig)
+})

--- a/contentscript.js
+++ b/contentscript.js
@@ -34,7 +34,7 @@ const lookup = (selectionText) =>
 
 const lookupInjected = () => {
     chrome.tabs.executeScript(null, {
-        code: `let text = ''; text = window.getSelection().toString() || selection.createRange().text`
+        code: `var text = ""; if (window.getSelection) { text = window.getSelection().toString(); } else if (document.selection && document.selection.type != "Control") { text = document.selection.createRange().text; }`
     }, lookup)
 }
 


### PR DESCRIPTION
I just refactore the code for more readable and functional. (removed semicolons, add ternary operators, create functions for new tabs e context menus, add ES6).

Fix problem with contextMenu not open tabs as word selected but with `[Object object]`. Line 36